### PR TITLE
Refactor more views into service layer

### DIFF
--- a/core/services/intranet_services.py
+++ b/core/services/intranet_services.py
@@ -1,0 +1,100 @@
+import core.serializers
+import core.utils.samples
+import core.utils.public_db
+import core.utils.bioinfo_analysis
+import core.utils.utils
+from . import get_lab_name_from_user
+
+
+def get_intranet_data_for_manager():
+    """Collect dashboard data for the manager intranet view."""
+    result = {"data": {}, "success": False, "errors": []}
+    try:
+        all_sample_per_date = core.utils.samples.get_sample_per_date_per_all_lab()
+        num_of_samples = core.utils.samples.count_handled_samples()
+        analysis_percent = core.utils.bioinfo_analysis.get_bio_analysis_stats_from_lab()
+
+        bar_config = {
+            "col_names": ["Sequencing Date", "Number of samples"],
+            "options": {"title": "Samples Received for all laboratories", "width": 590},
+        }
+
+        # dash graph for samples per lab
+        core.utils.samples.create_dash_bar_for_each_lab()
+
+        gisaid_raw = core.utils.public_db.get_public_accession_from_sample_lab("gisaid_accession_id")
+        ena_raw = core.utils.public_db.get_public_accession_from_sample_lab("ena_sample_accession")
+        actions_raw = core.utils.samples.get_lab_last_actions()
+
+        data = {
+            "sample_bar_graph": core.utils.samples.create_date_sample_bar(all_sample_per_date, bar_config),
+            "sample_gauge_graph": core.utils.utils.perc_gauge_graphic(analysis_percent),
+            "actions": core.serializers.LabLastActionSerializer.from_raw(actions_raw),
+        }
+
+        if gisaid_raw:
+            data["gisaid_accession"] = core.serializers.PublicAccessionSerializer.from_raw(gisaid_raw)
+            data["gisaid_graph"] = core.utils.public_db.percentage_graphic(
+                num_of_samples.get("Defined", 0), len(gisaid_raw), ""
+            )
+        if ena_raw:
+            data["ena_accession"] = core.serializers.PublicAccessionSerializer.from_raw(ena_raw)
+            data["ena_graph"] = core.utils.public_db.percentage_graphic(
+                num_of_samples.get("Defined", 0), len(ena_raw), ""
+            )
+
+        result["data"] = data
+        result["success"] = True
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": str(exc)})
+    return result
+
+
+def get_intranet_data_for_user(user):
+    """Collect dashboard data for a regular user."""
+    result = {"data": {}, "success": False, "errors": []}
+    try:
+        lab_name = get_lab_name_from_user(user)
+        date_lab_samples = core.utils.samples.get_sample_per_date_per_lab(lab_name)
+        if not date_lab_samples:
+            result["errors"].append({"code": 404, "message": f"No samples found for selected laboratory: {lab_name}"})
+            return result
+
+        sample_lab_objs = core.utils.samples.get_sample_objs_per_lab(lab_name)
+        analysis_percent = core.utils.bioinfo_analysis.get_bio_analysis_stats_from_lab(lab_name)
+
+        bar_config = {
+            "col_names": ["Sequencing Date", "Number of samples"],
+            "options": {"title": "Samples Received", "width": 600},
+        }
+
+        gisaid_raw = core.utils.public_db.get_public_accession_from_sample_lab(
+            "gisaid_accession_id", sample_lab_objs
+        )
+        ena_raw = core.utils.public_db.get_public_accession_from_sample_lab(
+            "ena_sample_accession", sample_lab_objs
+        )
+        actions_raw = core.utils.samples.get_lab_last_actions(lab_name)
+
+        data = {
+            "sample_bar_graph": core.utils.samples.create_date_sample_bar(date_lab_samples, bar_config),
+            "sample_gauge_graph": core.utils.utils.perc_gauge_graphic(analysis_percent),
+            "actions": core.serializers.LabLastActionDictSerializer.from_raw(actions_raw),
+        }
+
+        if gisaid_raw:
+            data["gisaid_accession"] = core.serializers.PublicAccessionSerializer.from_raw(gisaid_raw)
+            data["gisaid_graph"] = core.utils.public_db.percentage_graphic(
+                len(sample_lab_objs), len(gisaid_raw), ""
+            )
+        if ena_raw:
+            data["ena_accession"] = core.serializers.PublicAccessionSerializer.from_raw(ena_raw)
+            data["ena_graph"] = core.utils.public_db.percentage_graphic(
+                len(sample_lab_objs), len(ena_raw), ""
+            )
+
+        result["data"] = data
+        result["success"] = True
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": str(exc)})
+    return result

--- a/core/services/lab_services.py
+++ b/core/services/lab_services.py
@@ -1,0 +1,24 @@
+import core.utils.labs as labs_utils
+
+
+def handle_laboratory_contact(action=None, post_data=None, user=None):
+    """Retrieve or update laboratory contact information."""
+    result = {"data": {}, "success": False, "errors": []}
+    try:
+        lab_data = labs_utils.get_lab_contact_details(user)
+        if isinstance(lab_data, str):
+            result["errors"].append({"code": 500, "message": lab_data or "No laboratory data"})
+            return result
+
+        if action == "updateLabData" and post_data is not None:
+            update_result = labs_utils.update_contact_lab(lab_data, post_data)
+            if isinstance(update_result, dict):
+                result["errors"].append({"code": 500, "message": update_result.get("ERROR")})
+                return result
+            result["data"]["message"] = "Success"
+
+        result["data"]["lab_data"] = lab_data
+        result["success"] = len(result["errors"]) == 0
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": str(exc)})
+    return result

--- a/core/services/metadata_services.py
+++ b/core/services/metadata_services.py
@@ -1,0 +1,88 @@
+import core.utils.samples
+import core.config
+
+
+def handle_metadata_upload(metadata_file, username):
+    """Store uploaded metadata file into Samba."""
+    result = {"data": {}, "success": False, "errors": []}
+    try:
+        core.utils.samples.save_excel_form_in_samba_folder(metadata_file, username)
+        result["data"] = {"sample_recorded": {"ok": "OK"}}
+        result["success"] = True
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": str(exc)})
+    return result
+
+
+def handle_define_samples(post_data, user, schema_obj):
+    """Process the form for defining samples."""
+    result = {"data": {}, "success": False, "errors": []}
+    try:
+        res_analyze = core.utils.samples.analyze_input_samples(post_data, user)
+        if len(res_analyze) == 0:
+            m_form = core.utils.samples.create_metadata_form(schema_obj, user)
+            result["data"] = {"m_form": m_form}
+            result["success"] = True
+            return result
+        if "save_samples" in res_analyze:
+            s_saved = core.utils.samples.save_temp_sample_data(res_analyze["save_samples"], user)
+            result["data"]["sample_saved"] = s_saved
+        if "s_incomplete" in res_analyze or "s_already_record" in res_analyze:
+            m_form = None
+            if "s_incomplete" in res_analyze:
+                m_form = core.utils.samples.create_metadata_form(schema_obj, user)
+            result["data"] = {"sample_issues": res_analyze, "m_form": m_form}
+            result["success"] = True
+            return result
+        m_batch_form = core.utils.samples.create_form_for_batch(schema_obj, user)
+        sample_saved = core.utils.samples.get_sample_pre_recorded(user)
+        result["data"] = {"m_batch_form": m_batch_form, "sample_saved": sample_saved}
+        result["success"] = True
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": str(exc)})
+    return result
+
+
+def handle_define_batch(post_data, user, schema_obj):
+    """Handle metadata batch definition."""
+    result = {"data": {}, "success": False, "errors": []}
+    try:
+        if not core.utils.samples.check_if_empty_data(post_data):
+            sample_saved = core.utils.samples.get_sample_pre_recorded(user)
+            m_batch_form = core.utils.samples.create_form_for_batch(schema_obj, user)
+            result["data"] = {"m_batch_form": m_batch_form, "sample_saved": sample_saved}
+            result["success"] = True
+            return result
+        meta_data = core.utils.samples.join_sample_and_batch(post_data, user, schema_obj)
+        core.utils.samples.write_form_data_to_excel(meta_data, user)
+        core.utils.samples.delete_temporary_sample_table(user)
+        result["data"] = {"sample_recorded": {"ok": "OK"}}
+        result["success"] = True
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": str(exc)})
+    return result
+
+
+def get_metadata_form_initial(user, schema_obj):
+    """Return the initial data to display the metadata form."""
+    result = {"data": {}, "success": True, "errors": []}
+    try:
+        if core.utils.samples.pending_samples_in_metadata_form(user):
+            sample_saved = core.utils.samples.get_sample_pre_recorded(user)
+            m_batch_form = core.utils.samples.create_form_for_batch(schema_obj, user)
+            result["data"] = {"m_batch_form": m_batch_form, "sample_saved": sample_saved}
+            return result
+        m_form = core.utils.samples.create_metadata_form(schema_obj, user)
+        if "ERROR" in m_form:
+            result["success"] = False
+            result["errors"].append({"code": 500, "message": m_form["ERROR"]})
+            return result
+        if "None" in m_form["lab_name"] or m_form["lab_name"] == "":
+            result["success"] = False
+            result["errors"].append({"code": 400, "message": core.config.ERROR_USER_IS_NOT_ASSIGNED_TO_LAB})
+            return result
+        result["data"] = {"m_form": m_form}
+    except Exception as exc:
+        result["success"] = False
+        result["errors"].append({"code": 500, "message": str(exc)})
+    return result

--- a/core/templates/core/intranet.html
+++ b/core/templates/core/intranet.html
@@ -28,19 +28,23 @@
                         <hr>
                         <!-- Content Row -->
                         <div class="row" style="text-align: center;">
-                            {% if ERROR %}
+                            {% if errors %}
                                 <div class="row m-5">
                                     <div class="col-sm-12" >
                                         <div class="card  border-danger mb-3">
                                             <div class="card-header text-center text-danger"><h3 style="text-align:center">ERROR</h3> </div>
                                             <div class="card-body  text-center">
                                                 <br>
-                                                <p><strong>{{ERROR}}</strong></p>
+                                                <p>
+                                                {% for err in errors %}
+                                                    <strong>{{err.message}}</strong>{% if not forloop.last %}<br>{% endif %}
+                                                {% endfor %}
+                                                </p>
                                             </div> <!-- end card body  -->
                                         </div> <!-- end card  -->
                                     </div> <!--// end col-sm-9 -->
                                 </div> <!--// end row -->
-                            {% elif DATA %}
+                            {% elif data %}
                                 <div class="col-sm-12" >
                                     <div class="card">
                                         <div class="card-body">
@@ -62,12 +66,12 @@
                                                 <div class="tab-pane fade show active" id="samples" role="tabpanel" aria-labelledby="info-tab">
                                                     <div class="container-md">
                                                         <div class="row mt-4">
-                                                            {% if DATA.sample_bar_graph %}
+                                                            {% if data.sample_bar_graph %}
                                                                     <div class="col-md-7">
-                                                                            {{ DATA.sample_bar_graph | safe }}
+                                                                            {{ data.sample_bar_graph | safe }}
                                                                     </div> <!-- end col-md-7 -->
                                                                     <div class="col-md-5">
-                                                                            {{ DATA.sample_gauge_graph | safe }}
+                                                                            {{ data.sample_gauge_graph | safe }}
                                                                     </div> <!-- end col-md-5 -->
                                                                     <div class="col-md-12">
                                                                         {% plotly_app name="samplePerLabGraphic" ratio=1 %}
@@ -100,7 +104,7 @@
                                                                                 </tr>
                                                                             </thead>
                                                                             <tbody>
-                                                                                {% for lab, def, anal, gisaid, ena in DATA.actions %}
+                                                                                {% for lab, def, anal, gisaid, ena in data.actions %}
                                                                                     <tr>
                                                                                         <td>{{lab}}</td>
                                                                                         <td>{{def}}</td>
@@ -137,7 +141,7 @@
                                                                 <div class="card">
                                                                     <div class="card-header"><h2 style="text-align:center">ENA Samples accession</h2> </div>
                                                                     <div class="card-body">
-                                                                        {% if DATA.ena_accession %}
+                                                                        {% if data.ena_accession %}
                                                                             <table id="enaTable" class="table table-striped table-bordered">
                                                                                 <thead>
                                                                                     <tr scope="row">
@@ -146,7 +150,7 @@
                                                                                     </tr>
                                                                                 </thead>
                                                                                 <tbody>
-                                                                                    {% for lab, sample, acc in DATA.ena_accession %}
+                                                                                    {% for lab, sample, acc in data.ena_accession %}
                                                                                         <tr>
                                                                                             <td>{{sample}}</td>
                                                                                             <td>{{acc}}</td>
@@ -176,13 +180,13 @@
                                                                     </div> <!-- end card body-->
                                                                 </div> <!-- end card  -->
                                                             </div> <!-- end col-md-10 -->
-                                                            {% if DATA.ena_graph %}
+                                                            {% if data.ena_graph %}
                                                                 <div class="col-md-4">
                                                                     <div class="card">
                                                                         <div class="card-header"><h4 style="text-align:center">ENA Upload </h4> </div>
                                                                         <div class="card-body">
                                                                             <h5>Percentage of ENA upload samples</h5>
-                                                                            {{DATA.ena_graph | safe}}
+                                                                            {{data.ena_graph | safe}}
                                                                         </div> <!-- end card body-->
                                                                     </div> <!-- end card  -->
                                                                 </div> <!-- end col-md-9 -->
@@ -198,7 +202,7 @@
                                                                     <div class="card">
                                                                         <div class="card-header"><h2 style="text-align:center">GISAID Accession IDs </h2> </div>
                                                                         <div class="card-body">
-                                                                            {% if DATA.gisaid_accession %}
+                                                                            {% if data.gisaid_accession %}
                                                                                 <table id="gisaidTable" class="table table-striped table-bordered">
                                                                                     <thead>
                                                                                         <tr scope="row">
@@ -208,7 +212,7 @@
                                                                                         </tr>
                                                                                     </thead>
                                                                                     <tbody>
-                                                                                        {% for lab, sample, acc in DATA.gisaid_accession %}
+                                                                                        {% for lab, sample, acc in data.gisaid_accession %}
                                                                                             <tr>
                                                                                                 <td>{{lab}}</td>
                                                                                                 <td>{{sample}}</td>
@@ -239,13 +243,13 @@
                                                                         </div> <!-- end card body-->
                                                                     </div> <!-- end card  -->
                                                                 </div> <!-- end col-md-8 -->
-                                                                {% if DATA.gisaid_graph %}
+                                                                {% if data.gisaid_graph %}
                                                                     <div class="col-md-4">
                                                                         <div class="card">
                                                                             <div class="card-header"><h4 style="text-align:center">GISAID Upload </h4> </div>
                                                                             <div class="card-body">
                                                                                 <h5>Percentage of GISAID upload samples</h5>
-                                                                                {{DATA.gisaid_graph | safe}}
+                                                                                {{data.gisaid_graph | safe}}
                                                                             </div> <!-- end card body-->
                                                                         </div> <!-- end card  -->
                                                                     </div> <!-- end col-md-9 -->
@@ -280,12 +284,12 @@
                                             <div class="container-md">
                                                     <div class="row mt-4">
 
-                                                        {% if intra_data.sample_bar_graph %}
+                                                        {% if data.sample_bar_graph %}
                                                             <div class="col-md-7">
-                                                                    {{ intra_data.sample_bar_graph | safe }}
+                                                                    {{ data.sample_bar_graph | safe }}
                                                             </div> <!-- end col-md-7 -->
                                                             <div class="col-md-5">
-                                                                    {{ intra_data.sample_gauge_graph | safe }}
+                                                                    {{ data.sample_gauge_graph | safe }}
                                                             </div> <!-- end col-md-5 -->
 
                                                         {% else %}
@@ -318,10 +322,10 @@
                                                                         </thead>
                                                                         <tbody>
                                                                             <tr>
-                                                                                <td>{{intra_data.actions.Defined}}</td>
-                                                                                <td>{{intra_data.actions.Analysis}}</td>
-                                                                                <td>{{intra_data.actions.Gisaid}}</td>
-                                                                                <td>{{intra_data.actions.Ena}}</td>
+                                                                                <td>{{data.actions.Defined}}</td>
+                                                                                <td>{{data.actions.Analysis}}</td>
+                                                                                <td>{{data.actions.Gisaid}}</td>
+                                                                                <td>{{data.actions.Ena}}</td>
                                                                             </tr>
                                                                         </tbody>
                                                                     </table>
@@ -340,7 +344,7 @@
                                                             <div class="card">
                                                                 <div class="card-header"><h2 style="text-align:center">ENA Samples accession</h2> </div>
                                                                 <div class="card-body">
-                                                                    {% if intra_data.ena_accession %}
+                                                                    {% if data.ena_accession %}
                                                                         <table id="enaTable" class="table table-striped table-bordered">
                                                                             <thead>
                                                                                 <tr scope="row">
@@ -349,7 +353,7 @@
                                                                                 </tr>
                                                                             </thead>
                                                                             <tbody>
-                                                                                {% for sample, acc in intra_data.ena_accession %}
+                                                                                {% for sample, acc in data.ena_accession %}
                                                                                     <tr>
                                                                                         <td>{{sample}}</td>
                                                                                         <td>{{acc}}</td>
@@ -379,13 +383,13 @@
                                                                 </div> <!-- end card body-->
                                                             </div> <!-- end card  -->
                                                         </div> <!-- end col-md-10 -->
-                                                        {% if intra_data.ena_graph %}
+                                                        {% if data.ena_graph %}
                                                             <div class="col-md-4">
                                                                 <div class="card">
                                                                     <div class="card-header"><h4 style="text-align:center">ENA Upload </h4> </div>
                                                                     <div class="card-body">
                                                                         <h5>Percentage of ENA upload samples</h5>
-                                                                        {{intra_data.ena_graph | safe}}
+                                                                        {{data.ena_graph | safe}}
                                                                     </div> <!-- end card body-->
                                                                 </div> <!-- end card  -->
                                                             </div> <!-- end col-md-9 -->
@@ -401,7 +405,7 @@
                                                             <div class="card">
                                                                 <div class="card-header"><h2 style="text-align:center">GISAID Accession IDs </h2> </div>
                                                                 <div class="card-body">
-                                                                    {% if intra_data.gisaid_accession %}
+                                                                    {% if data.gisaid_accession %}
                                                                         <table id="gisaidTable" class="table table-striped table-bordered">
                                                                             <thead>
                                                                                 <tr scope="row">
@@ -410,7 +414,7 @@
                                                                                 </tr>
                                                                             </thead>
                                                                             <tbody>
-                                                                                {% for sample, acc in intra_data.gisaid_accession %}
+                                                                                {% for sample, acc in data.gisaid_accession %}
                                                                                     <tr>
                                                                                         <td>{{sample}}</td>
                                                                                         <td>{{acc}}</td>
@@ -441,13 +445,13 @@
                                                                 </div> <!-- end card body-->
                                                             </div> <!-- end card  -->
                                                         </div> <!-- end col-md-9 -->
-                                                        {% if intra_data.gisaid_graph %}
+                                                        {% if data.gisaid_graph %}
                                                             <div class="col-md-4">
                                                                 <div class="card">
                                                                     <div class="card-header"><h4 style="text-align:center">GISAID Upload </h4> </div>
                                                                     <div class="card-body">
                                                                         <h5>Percentage of GISAID upload samples</h5>
-                                                                        {{intra_data.gisaid_graph | safe}}
+                                                                        {{data.gisaid_graph | safe}}
                                                                     </div> <!-- end card body-->
                                                                 </div> <!-- end card  -->
                                                             </div> <!-- end col-md-9 -->

--- a/core/templates/core/laboratoryContact.html
+++ b/core/templates/core/laboratoryContact.html
@@ -25,17 +25,21 @@
                         </div>
                         <!-- Content Row -->
                         <div class="row justify-content-center">
-                            {% if ERROR %}
+                            {% if errors %}
                                     <div class="col-sm-10" >
                                         <div class="card  border-danger mb-3">
                                             <div class="card-header text-center text-danger"><h3 style="text-align:center">ERROR</h3> </div>
                                             <div class="card-body  text-center">
                                                 <br>
-                                                <p><strong>{{ERROR}}</strong></p>
+                                                <p>
+                                                {% for err in errors %}
+                                                    <strong>{{err.message}}</strong>{% if not forloop.last %}<br>{% endif %}
+                                                {% endfor %}
+                                                </p>
                                             </div> <!-- end card body  -->
                                         </div> <!-- end card  -->
                                     </div> <!--// end col-sm-9 -->
-                            {% elif Success %}
+                            {% elif success %}
                                     <div class="col-sm-10" >
                                         <div class="card  border-default mb-3">
                                             <div class="card-header text-center"><h3 style="text-align:center">Successul update </h3> </div>

--- a/core/views.py
+++ b/core/views.py
@@ -18,6 +18,9 @@ import core.config
 import core.services
 from core.services import schema_services
 from core.services import sample_services
+from core.services import intranet_services
+from core.services import metadata_services
+from core.services import lab_services
 
 
 # Imports for received samples graphic at intranet
@@ -153,26 +156,26 @@ def intranet(request):
     )
 
     if is_manager:
-        response = core.services.get_intranet_data_for_manager()
+        response = intranet_services.get_intranet_data_for_manager()
         return render(
             request,
             "core/intranet.html",
             {
-                "DATA": response["data"],
-                "SUCCESS": response["success"],
-                "ERROR": response["errors"],
+                "data": response["data"],
+                "success": response["success"],
+                "errors": response["errors"],
             },
         )
 
     # TODO: Didn't tested due to lack of bioinfodata (api related issues)
-    response = core.services.get_intranet_data_for_user(request.user)
+    response = intranet_services.get_intranet_data_for_user(request.user)
     return render(
         request,
         "core/intranet.html",
         {
-            "DATA": response["data"],
-            "SUCCESS": response["success"],
-            "ERROR": response["errors"],
+            "data": response["data"],
+            "success": response["success"],
+            "errors": response["errors"],
         },
     )
 
@@ -188,20 +191,20 @@ def metadata_form(request):
     if request.method == "POST":
         action = request.POST.get("action")
         if action == "uploadMetadataFile" and "metadataFile" in request.FILES:
-            response = core.services.handle_metadata_upload(
+            response = metadata_services.handle_metadata_upload(
                 request.FILES["metadataFile"], request.user.username
             )
             return render(
                 request, "core/metadataForm.html",
                 {
                     "DATA_SAMPLERECORDED": response["data"].get("sample_recorded"),
-                    "SUCCESS": response["success"],
-                    "ERROR": response["errors"]
+                    "success": response["success"],
+                    "errors": response["errors"]
                 }
             )
         #TODO: fix in progress
         if action == "defineSamples":
-            response = core.services.handle_define_samples(
+            response = metadata_services.handle_define_samples(
                 request.POST, request.user, schema_obj
             )
             if "sample_issues" in response["data"]:
@@ -210,8 +213,8 @@ def metadata_form(request):
                     {
                         "DATA_SAMPLEISSUES": response["data"]["sample_issues"],
                         "DATA_FORM": response["data"]["m_form"],
-                        "SUCCESS": response["success"],
-                        "ERROR": response["errors"]
+                        "success": response["success"],
+                        "errors": response["errors"]
                     }
                 )
             if "m_form" in response["data"]:
@@ -219,8 +222,8 @@ def metadata_form(request):
                     request, "core/metadataForm.html",
                     {
                         "DATA_FORM": response["data"]["m_form"],
-                        "SUCCESS": response["success"],
-                        "ERROR": response["errors"]
+                        "success": response["success"],
+                        "errors": response["errors"]
                     }
                 )
             if "m_batch_form" in response["data"]:
@@ -229,8 +232,8 @@ def metadata_form(request):
                     {
                         "DATA_BATCHFORM": response["data"]["m_batch_form"],
                         "DATA_SAMPLESAVED": response["data"]["sample_saved"],
-                        "SUCCESS": response["success"],
-                        "ERROR": response["errors"]
+                        "success": response["success"],
+                        "errors": response["errors"]
                     }
                 )
             if "sample_saved" in response["data"]:
@@ -238,13 +241,13 @@ def metadata_form(request):
                     request, "core/metadataForm.html",
                     {
                         "DATA_SAMPLESAVED": response["data"]["sample_saved"],
-                        "SUCCESS": response["success"],
-                        "ERROR": response["errors"]
+                        "success": response["success"],
+                        "errors": response["errors"]
                     }
                 )
 
         if action == "defineBatch":
-            response = core.services.handle_define_batch(
+            response = metadata_services.handle_define_batch(
                 request.POST, request.user, schema_obj
             )
             if "m_batch_form" in response["data"]:
@@ -253,8 +256,8 @@ def metadata_form(request):
                     {
                         "DATA_BATCHFORM": response["data"]["m_batch_form"],
                         "DATA_SAMPLESAVED": response["data"]["sample_saved"],
-                        "SUCCESS": response["success"],
-                        "ERROR": response["errors"]
+                        "success": response["success"],
+                        "errors": response["errors"]
                     }
                 )
             if "sample_recorded" in response["data"]:
@@ -262,34 +265,34 @@ def metadata_form(request):
                     request, "core/metadataForm.html",
                     {
                         "DATA_SAMPLERECORDED": response["data"]["sample_recorded"],
-                        "SUCCESS": response["success"],
-                        "ERROR": response["errors"]
+                        "success": response["success"],
+                        "errors": response["errors"]
                     }
                 )
 
     # GET request or fallback
-    response = core.services.get_metadata_form_initial(request.user, schema_obj)
+    response = metadata_services.get_metadata_form_initial(request.user, schema_obj)
     if "m_batch_form" in response["data"]:
         return render(
             request, "core/metadataForm.html",
             {
                 "DATA_BATCHFORM": response["data"]["m_batch_form"],
                 "DATA_SAMPLESAVED": response["data"]["sample_saved"],
-                "SUCCESS": response["success"],
-                "ERROR": response["errors"]
+                "success": response["success"],
+                "errors": response["errors"]
             }
         )
     if not response["success"]:
         return render(
             request, "core/metadataForm.html",
-            {"ERROR": response["errors"]}
+            {"errors": response["errors"]}
         )
     return render(
         request, "core/metadataForm.html",
         {
             "DATA_FORM": response["data"]["m_form"],
-            "SUCCESS": response["success"],
-            "ERROR": response["errors"]
+            "success": response["success"],
+            "errors": response["errors"]
         }
     )
 
@@ -319,18 +322,18 @@ def organism_annotation(request):
     annotations = core.utils.annotation.get_annotations()
     if request.method == "POST" and request.POST["action"] == "uploadAnnotation":
         gff_parsed = core.utils.annotation.read_gff_file(request.FILES["gffFile"])
-        if "ERROR" in gff_parsed:
+        if "errors" in gff_parsed:
             return render(
                 request,
                 "core/organismAnnotation.html",
-                {"ERROR": gff_parsed["ERROR"], "annotations": annotations},
+                {"errors": gff_parsed["errors"], "annotations": annotations},
             )
         core.utils.annotation.store_gff(gff_parsed, request.user)
         annotations = core.utils.annotation.get_annotations()
         return render(
             request,
             "core/organismAnnotation.html",
-            {"SUCCESS": "Success", "annotations": annotations},
+            {"success": "Success", "annotations": annotations},
         )
     return render(request, "core/organismAnnotation.html", {"annotations": annotations})
 
@@ -338,21 +341,18 @@ def organism_annotation(request):
 # TODO: this needs serialized-based refactor
 @login_required()
 def laboratory_contact(request):
-    lab_data = core.utils.labs.get_lab_contact_details(request.user)
-    if "ERROR" in lab_data:
-        return render(
-            request, "core/laboratoryContact.html", {"ERROR": lab_data["ERROR"]}
-        )
-    if request.method == "POST" and request.POST["action"] == "updateLabData":
-        result = core.utils.labs.update_contact_lab(lab_data, request.POST)
-        if isinstance(result, dict):
-            return render(
-                request,
-                "core/laboratoryContact.html",
-                {"ERROR": result["ERROR"]},
-            )
-        return render(request, "core/laboratoryContact.html", {"Success": "Success"})
-    return render(request, "core/laboratoryContact.html", {"lab_data": lab_data})
+    action = request.POST.get("action") if request.method == "POST" else None
+    response = lab_services.handle_laboratory_contact(
+        action=action,
+        post_data=request.POST if request.method == "POST" else None,
+        user=request.user,
+    )
+    context = {
+        **response.get("data", {}),
+        "success": response.get("success"),
+        "errors": response.get("errors"),
+    }
+    return render(request, "core/laboratoryContact.html", context)
 
 
 # TODO: this needs serialized-based refactor


### PR DESCRIPTION
## Summary
- create `intranet_services`, `metadata_services` and `lab_services`
- refactor intranet view to use new service and update template variables
- refactor metadata form logic into its own service
- refactor laboratory contact view and template to standard context keys

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: W503/W504 style warnings)*
