### PR TITLE
Refactor into views to services approach

### DIFF
--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -11,6 +11,7 @@ import core.utils.rest_api
 import core.utils.schema
 import core.utils.variants
 import core.utils.samples
+import core.utils.labs
 import core.utils.bioinfo_analysis
 import core.utils.generic_functions
 import json
@@ -72,97 +73,11 @@ def get_index_data():
     return result
 
 
-def get_all_defined_labs():
-    """Get a list of laboratories that are defined in iSkyLIMS"""
-    sum_data = core.utils.rest_api.get_summarize_data(None)
-    if "ERROR" in sum_data:
-        return sum_data
-    return list(sum_data["laboratory"].keys())
-
-
-def get_defined_users():
-    """Get the id and the user names defined in relecov"""
-    user_list = []
-    user_objs = (
-        core.models.User.objects.all()
-        .exclude(username__iexact="admin")
-        .order_by("username")
-    )
-    for user_obj in user_objs:
-        user_list.append([user_obj.pk, user_obj.username])
-    return user_list
-
-
-def get_labs_and_users_data():
-    labs = get_all_defined_labs()
-    users = get_defined_users()
-    return core.serializers.LabUserAssignSerializer.from_raw_data(
-        labs=labs,
-        users=users,
-    )
-
-
 def get_sample_obj_from_id(sample_id):
     """Return the sample instance from its id"""
     if core.models.Sample.objects.filter(pk__exact=sample_id).exists():
         return core.models.Sample.objects.filter(pk__exact=sample_id).last()
     return None
-
-
-def get_assign_samples_data(action=None, lab=None, user_id=None):
-    result = {"data": {}, "success": False, "errors": []}
-    labs = get_all_defined_labs()
-    users = get_defined_users()
-
-    if action == "assignSamples":
-        if not user_id:
-            result["errors"].append({"code": 400, "message": "No user selected."})
-        else:
-            try:
-                user_obj = core.models.User.objects.get(pk=user_id)
-                samples_qs = core.models.Sample.objects.filter(
-                    collecting_institution__iexact=lab
-                )
-                if samples_qs.exists():
-                    samples_qs.update(user=user_obj)
-                    result["data"] = (
-                        core.serializers.LabUserAssignSerializer.from_raw_data(
-                            labs, users, SUCCESS="Samples reassigned."
-                        )
-                    )
-                    result["success"] = True
-                else:
-                    result["errors"].append(
-                        {
-                            "code": 404,
-                            "message": f"{core.config.ERROR_NO_SAMPLES_ARE_ASSIGNED_TO_LAB} {lab}",
-                        }
-                    )
-            except core.models.User.DoesNotExist:
-                result["errors"].append(
-                    {"code": 404, "message": f"User with ID {user_id} does not exist."}
-                )
-    else:
-        result["data"] = core.serializers.LabUserAssignSerializer.from_raw_data(
-            labs, users
-        )
-        result["success"] = True
-    return result
-
-
-def get_labs_and_users():
-    """Prepares data for sample allocation form."""
-    raw_data = {"labs": get_all_defined_labs(), "users": get_defined_users()}
-    return core.serializers.LabUserDataSerializer.from_raw_data(raw_data)
-
-
-def get_lab_name_from_user(user_obj):
-    """Get the laboratory name for the user"""
-    if core.models.Profile.objects.filter(user=user_obj).exists():
-        profile_obj = core.models.Profile.objects.filter(user=user_obj).last()
-        return profile_obj.get_lab_name()
-    else:
-        return ""
 
 
 # FIXME: refactor its output
@@ -180,11 +95,11 @@ def get_search_data(user_obj):
     # Get laboratories available in the user's group
     group = Group.objects.get(name="RelecovManager")
     if group in user_obj.groups.all():
-        labs = get_all_defined_labs()
+        labs = core.utils.labs.get_all_defined_labs()
         if isinstance(labs, dict) and "ERROR" in labs:
             labs = ["", ""]
     else:
-        labs = [get_lab_name_from_user(user_obj)]
+        labs = [core.utils.labs.get_lab_name_from_user(user_obj)]
 
     return {
         "labs": labs,

--- a/core/services/annotation_services.py
+++ b/core/services/annotation_services.py
@@ -1,0 +1,52 @@
+"""Services for organism annotations."""
+
+from typing import Optional
+
+import core.utils.annotation
+
+
+def get_annotation_details(annot_id: int) -> dict:
+    """Retrieve annotation detail data."""
+    result = {"data": {}, "success": False, "errors": []}
+    try:
+        if not core.utils.annotation.check_if_annotation_exists(annot_id):
+            result["errors"].append(
+                {"code": 404, "message": "Annotation does not exist"}
+            )
+            return result
+        annot_data = core.utils.annotation.get_annotation_data(annot_id)
+        result["data"]["annotation_data"] = annot_data
+        result["success"] = True
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": str(exc)})
+    return result
+
+
+def handle_organism_annotation(
+    action: Optional[str], *, gff_file=None, user=None
+) -> dict:
+    """Handle organism annotation upload and retrieval."""
+    result = {"data": {}, "success": False, "errors": []}
+    try:
+        annotations = core.utils.annotation.get_annotations()
+        result["data"]["annotations"] = annotations
+
+        if action == "uploadAnnotation":
+            if not gff_file:
+                result["errors"].append(
+                    {"code": 400, "message": "No file provided"}
+                )
+                return result
+            gff_parsed = core.utils.annotation.read_gff_file(gff_file)
+            if "ERROR" in gff_parsed:
+                result["errors"].append({"code": 400, "message": gff_parsed["ERROR"]})
+                return result
+            core.utils.annotation.store_gff(gff_parsed, user)
+            result["data"]["annotations"] = core.utils.annotation.get_annotations()
+            result["success"] = True
+            return result
+
+        result["success"] = True
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": str(exc)})
+    return result

--- a/core/services/assignment_services.py
+++ b/core/services/assignment_services.py
@@ -1,0 +1,54 @@
+import core.config
+import core.models
+import core.serializers
+import core.utils.labs as labs_utils
+
+
+def _get_defined_users():
+    """Return list of [id, username] for all users except admin."""
+    user_list = []
+    user_objs = core.models.User.objects.all().exclude(username__iexact="admin").order_by("username")
+    for user_obj in user_objs:
+        user_list.append([user_obj.pk, user_obj.username])
+    return user_list
+
+
+def handle_assign_samples_to_user(action=None, post_data=None, user=None):
+    """Assign samples belonging to a lab to a given user."""
+    result = {"data": {}, "success": False, "errors": []}
+    labs = labs_utils.get_all_defined_labs()
+    users = _get_defined_users()
+
+    if isinstance(labs, dict) and "ERROR" in labs:
+        result["errors"].append({"code": 500, "message": labs.get("ERROR", "Error loading labs")})
+        return result
+
+    if action == "assignSamples":
+        lab = post_data.get("lab") if post_data else None
+        user_id = post_data.get("userName") if post_data else None
+        if not user_id:
+            result["errors"].append({"code": 400, "message": "No user selected."})
+        else:
+            try:
+                user_obj = core.models.User.objects.get(pk=user_id)
+                samples_qs = core.models.Sample.objects.filter(collecting_institution__iexact=lab)
+                if samples_qs.exists():
+                    samples_qs.update(user=user_obj)
+                    result["data"] = core.serializers.LabUserAssignSerializer.from_raw_data(
+                        labs, users, SUCCESS="Samples reassigned."
+                    )
+                    result["success"] = True
+                else:
+                    result["errors"].append({
+                        "code": 404,
+                        "message": f"{core.config.ERROR_NO_SAMPLES_ARE_ASSIGNED_TO_LAB} {lab}",
+                    })
+            except core.models.User.DoesNotExist:
+                result["errors"].append({
+                    "code": 404,
+                    "message": f"User with ID {user_id} does not exist.",
+                })
+    else:
+        result["data"] = core.serializers.LabUserAssignSerializer.from_raw_data(labs, users)
+        result["success"] = True
+    return result

--- a/core/services/intranet_services.py
+++ b/core/services/intranet_services.py
@@ -98,3 +98,10 @@ def get_intranet_data_for_user(user):
     except Exception as exc:
         result["errors"].append({"code": 500, "message": str(exc)})
     return result
+
+
+def get_intranet_data(user):
+    """Return intranet dashboard data based on user permissions."""
+    if user.groups.filter(name="RelecovManager").exists():
+        return get_intranet_data_for_manager()
+    return get_intranet_data_for_user(user)

--- a/core/services/intranet_services.py
+++ b/core/services/intranet_services.py
@@ -3,7 +3,7 @@ import core.utils.samples
 import core.utils.public_db
 import core.utils.bioinfo_analysis
 import core.utils.utils
-from . import get_lab_name_from_user
+import core.utils.labs as labs_utils
 
 
 def get_intranet_data_for_manager():
@@ -54,7 +54,7 @@ def get_intranet_data_for_user(user):
     """Collect dashboard data for a regular user."""
     result = {"data": {}, "success": False, "errors": []}
     try:
-        lab_name = get_lab_name_from_user(user)
+        lab_name = labs_utils.get_lab_name_from_user(user)
         date_lab_samples = core.utils.samples.get_sample_per_date_per_lab(lab_name)
         if not date_lab_samples:
             result["errors"].append({"code": 404, "message": f"No samples found for selected laboratory: {lab_name}"})

--- a/core/services/metadata_services.py
+++ b/core/services/metadata_services.py
@@ -1,8 +1,9 @@
+# Service layer helpers
 import core.utils.samples
 import core.config
 
 
-def handle_metadata_upload(metadata_file, username):
+def _handle_metadata_upload(metadata_file, username):
     """Store uploaded metadata file into Samba."""
     result = {"data": {}, "success": False, "errors": []}
     try:
@@ -14,7 +15,7 @@ def handle_metadata_upload(metadata_file, username):
     return result
 
 
-def handle_define_samples(post_data, user, schema_obj):
+def _handle_define_samples(post_data, user, schema_obj):
     """Process the form for defining samples."""
     result = {"data": {}, "success": False, "errors": []}
     try:
@@ -43,7 +44,7 @@ def handle_define_samples(post_data, user, schema_obj):
     return result
 
 
-def handle_define_batch(post_data, user, schema_obj):
+def _handle_define_batch(post_data, user, schema_obj):
     """Handle metadata batch definition."""
     result = {"data": {}, "success": False, "errors": []}
     try:
@@ -63,7 +64,7 @@ def handle_define_batch(post_data, user, schema_obj):
     return result
 
 
-def get_metadata_form_initial(user, schema_obj):
+def _get_metadata_form_initial(user, schema_obj):
     """Return the initial data to display the metadata form."""
     result = {"data": {}, "success": True, "errors": []}
     try:
@@ -86,3 +87,34 @@ def get_metadata_form_initial(user, schema_obj):
         result["success"] = False
         result["errors"].append({"code": 500, "message": str(exc)})
     return result
+
+
+def handle_metadata_form(action=None, post_data=None, files=None, user=None, schema_obj=None):
+    """Central entry point for metadata form actions."""
+    if action == "uploadMetadataFile" and files:
+        response = _handle_metadata_upload(files.get("metadataFile"), user.username)
+    elif action == "defineSamples":
+        response = _handle_define_samples(post_data, user, schema_obj)
+    elif action == "defineBatch":
+        response = _handle_define_batch(post_data, user, schema_obj)
+    else:
+        response = _get_metadata_form_initial(user, schema_obj)
+
+    mapped_data = {}
+    source = response.get("data", {})
+    if "m_form" in source:
+        mapped_data["DATA_FORM"] = source["m_form"]
+    if "sample_issues" in source:
+        mapped_data["DATA_SAMPLEISSUES"] = source["sample_issues"]
+    if "m_batch_form" in source:
+        mapped_data["DATA_BATCHFORM"] = source["m_batch_form"]
+    if "sample_saved" in source:
+        mapped_data["DATA_SAMPLESAVED"] = source["sample_saved"]
+    if "sample_recorded" in source:
+        mapped_data["DATA_SAMPLERECORDED"] = source["sample_recorded"]
+
+    return {
+        "data": mapped_data,
+        "success": response.get("success"),
+        "errors": response.get("errors"),
+    }

--- a/core/services/sample_services.py
+++ b/core/services/sample_services.py
@@ -1,5 +1,8 @@
 from . import get_search_data, validate_search_params, display_samples
 
+import core.utils.samples_map
+import core.utils.samples_graphics
+
 
 def handle_sample_search(action=None, sample_name="", s_date="", lab_name="", sample_state="", user=None):
     """Orchestrate sample search workflow."""
@@ -26,4 +29,49 @@ def handle_sample_search(action=None, sample_name="", s_date="", lab_name="", sa
     result["data"].update(display_result.get("data", {}))
     result["errors"].extend(display_result.get("errors", []))
     result["success"] = display_result.get("success", False) and not result["errors"]
+    return result
+
+
+def get_received_samples_data():
+    """Gather dashboard information about received samples."""
+    result = {"data": {}, "success": False, "errors": []}
+    sample_data = {}
+
+    try:
+        map_result = core.utils.samples_map.create_samples_received_map()
+        sample_data["map"] = map_result
+        if isinstance(map_result, dict) and map_result.get("ERROR"):
+            result["errors"].append({"code": 500, "message": map_result["ERROR"]})
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": f"Error generating map: {exc}"})
+        sample_data["map"] = {}
+
+    try:
+        sample_data["received_samples_graph"] = (
+            core.utils.samples_graphics.received_samples_graph()
+        )
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": f"Error generating samples graph: {exc}"})
+        sample_data["received_samples_graph"] = {}
+
+    try:
+        per_ccaa = core.utils.samples_graphics.received_per_ccaa()
+        sample_data["samples_per_ccaa"] = per_ccaa
+        if isinstance(per_ccaa, dict) and per_ccaa.get("ERROR"):
+            result["errors"].append({"code": 500, "message": per_ccaa["ERROR"]})
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": f"Error generating CCAA chart: {exc}"})
+        sample_data["samples_per_ccaa"] = {}
+
+    try:
+        per_lab = core.utils.samples_graphics.received_per_lab()
+        sample_data["samples_per_lab"] = per_lab
+        if isinstance(per_lab, dict) and per_lab.get("ERROR"):
+            result["errors"].append({"code": 500, "message": per_lab["ERROR"]})
+    except Exception as exc:
+        result["errors"].append({"code": 500, "message": f"Error generating laboratory chart: {exc}"})
+        sample_data["samples_per_lab"] = {}
+
+    result["data"]["sample_data"] = sample_data
+    result["success"] = len(result["errors"]) == 0
     return result

--- a/core/utils/labs.py
+++ b/core/utils/labs.py
@@ -3,6 +3,14 @@ import core.models
 import core.utils.rest_api
 
 
+def get_all_defined_labs():
+    """Return the list of laboratories defined in iSkyLIMS."""
+    sum_data = core.utils.rest_api.get_summarize_data(None)
+    if "ERROR" in sum_data:
+        return sum_data
+    return list(sum_data["laboratory"].keys())
+
+
 def get_lab_contact_details(user_obj):
     lab_data = {}
     lab_name = get_lab_name_from_user(user_obj)

--- a/core/utils/samples.py
+++ b/core/utils/samples.py
@@ -10,7 +10,6 @@ from django.core.files.storage import FileSystemStorage
 from django.conf import settings
 from django.db.models import Q
 from django.db.models import Count
-import core.services
 import relecov_tools.utils
 
 # Local imports
@@ -563,13 +562,13 @@ def get_search_data(user_obj):
     # Allow to search information from any laboratoryr
     group = Group.objects.get(name="RelecovManager")
     if group in user_obj.groups.all():
-        def_labs = core.services.get_all_defined_labs()
+        def_labs = core.utils.labs.get_all_defined_labs()
         if "ERROR" in def_labs:
             s_data["labs"] = ["", ""]
         else:
             s_data["labs"] = def_labs
     else:
-        s_data["labs"] = core.services.get_lab_name_from_user(user_obj)
+        s_data["labs"] = core.utils.labs.get_lab_name_from_user(user_obj)
 
     return s_data
 

--- a/core/views.py
+++ b/core/views.py
@@ -1,7 +1,6 @@
 # Generic imports
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import Group
 import core.api.serializers
 
 # Local imports
@@ -150,33 +149,13 @@ def metadata_visualization(request):
 
 @login_required
 def intranet(request):
-    is_manager = (
-        Group.objects.filter(name="RelecovManager").last() in request.user.groups.all()
-    )
-
-    if is_manager:
-        response = intranet_services.get_intranet_data_for_manager()
-        return render(
-            request,
-            "core/intranet.html",
-            {
-                "data": response["data"],
-                "success": response["success"],
-                "errors": response["errors"],
-            },
-        )
-
-    # TODO: Didn't tested due to lack of bioinfodata (api related issues)
-    response = intranet_services.get_intranet_data_for_user(request.user)
-    return render(
-        request,
-        "core/intranet.html",
-        {
-            "data": response["data"],
-            "success": response["success"],
-            "errors": response["errors"],
-        },
-    )
+    response = intranet_services.get_intranet_data(request.user)
+    context = {
+        **response.get("data", {}),
+        "success": response.get("success"),
+        "errors": response.get("errors"),
+    }
+    return render(request, "core/intranet.html", context)
 
 
 def variants(request):

--- a/core/views.py
+++ b/core/views.py
@@ -21,6 +21,7 @@ from core.services import sample_services
 from core.services import intranet_services
 from core.services import metadata_services
 from core.services import lab_services
+from core.services import assignment_services
 
 
 # Imports for received samples graphic at intranet
@@ -36,27 +37,23 @@ def index(request):
     return render(request, "core/index.html", {"data": index_data["data"]})
 
 
-@login_required
+@login_required()
 def assign_samples_to_user(request):
     if request.user.username != "admin":
         return redirect("/")
 
-    action = request.POST.get("action") if request.POST else None
-    lab = request.POST.get("lab")
-    user_id = request.POST.get("userName")
-
-    response = core.services.get_assign_samples_data(
-        action=action, lab=lab, user_id=user_id
+    action = request.POST.get("action") if request.method == "POST" else None
+    response = assignment_services.handle_assign_samples_to_user(
+        action=action,
+        post_data=request.POST if request.method == "POST" else None,
+        user=request.user,
     )
-    return render(
-        request,
-        "core/assignSamplesToUser.html",
-        {
-            "data": response["data"],
-            "success": response["success"] if action else None,
-            "errors": response["errors"],
-        },
-    )
+    context = {
+        **response.get("data", {}),
+        "success": response.get("success"),
+        "errors": response.get("errors"),
+    }
+    return render(request, "core/assignSamplesToUser.html", context)
 
 
 # TODO: Discuss whether render shuld be used once or twice (one if not result["success"] and another one if result["success"]). Example below shows an scenario where render is used once, letting the logic of errors to be addressed in the tempalte.

--- a/core/views.py
+++ b/core/views.py
@@ -52,8 +52,6 @@ def assign_samples_to_user(request):
     return render(request, "core/assignSamplesToUser.html", context)
 
 
-# TODO: Discuss whether render shuld be used once or twice (one if not result["success"] and another one if result["success"]). Example below shows an scenario where render is used once, letting the logic of errors to be addressed in the tempalte.
-# TODO: I think it would be better to put here the request POST/GET logic.
 @login_required
 def schema_handling(request):
     if request.user.username != "admin":
@@ -156,7 +154,7 @@ def intranet(request):
 def variants(request):
     return render(request, "core/variants.html", {})
 
-# TODO: too many utils to apply serializer refactor
+
 @login_required()
 def metadata_form(request):
     schema_obj = core.utils.schema.get_latest_schema("relecov", __package__)

--- a/core/views.py
+++ b/core/views.py
@@ -11,7 +11,6 @@ import core.utils.labs
 import core.utils.public_db
 import core.utils.variants
 import core.utils.generic_functions
-import core.utils.annotation
 import core.utils.lineage
 import core.config
 import core.services
@@ -21,6 +20,7 @@ from core.services import intranet_services
 from core.services import metadata_services
 from core.services import lab_services
 from core.services import assignment_services
+from core.services import annotation_services
 
 
 # Imports for received samples graphic at intranet
@@ -182,48 +182,46 @@ def metadata_form(request):
     return render(request, "core/metadataForm.html", context)
 
 
-# TODO: this needs serialized-based refactor
 @login_required()
 def annotation_display(request, annot_id):
-    """Display the full information about the organism annotation stored in
-    database
-    """
+    """Display the full information about a stored organism annotation."""
     if request.user.username != "admin":
         return redirect("/")
-    if not core.utils.annotation.check_if_annotation_exists(annot_id):
+
+    response = annotation_services.get_annotation_details(annot_id)
+    if any(err.get("code") == 404 for err in response.get("errors", [])):
         return render(request, "core/error_404.html")
-    annot_data = core.utils.annotation.get_annotation_data(annot_id)
-    return render(
-        request, "core/annotationDisplay.html", {"annotation_data": annot_data}
-    )
+
+    context = {
+        **response.get("data", {}),
+        "success": response.get("success"),
+        "errors": response.get("errors"),
+    }
+    return render(request, "core/annotationDisplay.html", context)
 
 
-# TODO: this needs serialized-based refactor
 @login_required()
 def organism_annotation(request):
-    """Store the organism annotation gff file"""
+    """Store the organism annotation GFF file."""
     if request.user.username != "admin":
         return redirect("/")
-    annotations = core.utils.annotation.get_annotations()
-    if request.method == "POST" and request.POST["action"] == "uploadAnnotation":
-        gff_parsed = core.utils.annotation.read_gff_file(request.FILES["gffFile"])
-        if "errors" in gff_parsed:
-            return render(
-                request,
-                "core/organismAnnotation.html",
-                {"errors": gff_parsed["errors"], "annotations": annotations},
-            )
-        core.utils.annotation.store_gff(gff_parsed, request.user)
-        annotations = core.utils.annotation.get_annotations()
-        return render(
-            request,
-            "core/organismAnnotation.html",
-            {"success": "Success", "annotations": annotations},
-        )
-    return render(request, "core/organismAnnotation.html", {"annotations": annotations})
+
+    action = request.POST.get("action") if request.method == "POST" else None
+    gff_file = request.FILES.get("gffFile") if request.method == "POST" else None
+
+    response = annotation_services.handle_organism_annotation(
+        action=action,
+        gff_file=gff_file,
+        user=request.user,
+    )
+    context = {
+        **response.get("data", {}),
+        "success": response.get("success"),
+        "errors": response.get("errors"),
+    }
+    return render(request, "core/organismAnnotation.html", context)
 
 
-# TODO: this needs serialized-based refactor
 @login_required()
 def laboratory_contact(request):
     action = request.POST.get("action") if request.method == "POST" else None

--- a/core/views.py
+++ b/core/views.py
@@ -23,11 +23,6 @@ from core.services import assignment_services
 from core.services import annotation_services
 
 
-# Imports for received samples graphic at intranet
-import core.utils.samples_graphics
-import core.utils.samples_map
-
-
 def index(request):
     response = core.services.get_index_data()
     context = {
@@ -238,31 +233,15 @@ def laboratory_contact(request):
     return render(request, "core/laboratoryContact.html", context)
 
 
-# TODO: this needs serialized-based refactor
-@login_required
+@login_required()
 def received_samples(request):
-    sample_data = {}
-    # samples receive over time map
-    sample_data["map"] = core.utils.samples_map.create_samples_received_map()
-    # samples receive over time graph
-    # df = create_dataframe_from_json()
-    # create_samples_over_time_graph(df)
-
-    # # collecting now data from database
-    sample_data["received_samples_graph"] = (
-        core.utils.samples_graphics.received_samples_graph()
-    )
-    # Pie charts
-    # data = parse_json_file()
-    # create_samples_received_over_time_per_ccaa_pieChart(data)
-    sample_data["samples_per_ccaa"] = core.utils.samples_graphics.received_per_ccaa()
-    # create_samples_received_over_time_per_laboratory_pieChart(data)
-    sample_data["samples_per_lab"] = core.utils.samples_graphics.received_per_lab()
-    return render(
-        request,
-        "core/receivedSamples.html",
-        {"sample_data": sample_data},
-    )
+    response = sample_services.get_received_samples_data()
+    context = {
+        **response.get("data", {}),
+        "success": response.get("success"),
+        "errors": response.get("errors"),
+    }
+    return render(request, "core/receivedSamples.html", context)
 
 
 def contact(request):

--- a/core/views.py
+++ b/core/views.py
@@ -166,113 +166,20 @@ def variants(request):
 def metadata_form(request):
     schema_obj = core.utils.schema.get_latest_schema("relecov", __package__)
 
-    if request.method == "POST":
-        action = request.POST.get("action")
-        if action == "uploadMetadataFile" and "metadataFile" in request.FILES:
-            response = metadata_services.handle_metadata_upload(
-                request.FILES["metadataFile"], request.user.username
-            )
-            return render(
-                request, "core/metadataForm.html",
-                {
-                    "DATA_SAMPLERECORDED": response["data"].get("sample_recorded"),
-                    "success": response["success"],
-                    "errors": response["errors"]
-                }
-            )
-        #TODO: fix in progress
-        if action == "defineSamples":
-            response = metadata_services.handle_define_samples(
-                request.POST, request.user, schema_obj
-            )
-            if "sample_issues" in response["data"]:
-                return render(
-                    request, "core/metadataForm.html",
-                    {
-                        "DATA_SAMPLEISSUES": response["data"]["sample_issues"],
-                        "DATA_FORM": response["data"]["m_form"],
-                        "success": response["success"],
-                        "errors": response["errors"]
-                    }
-                )
-            if "m_form" in response["data"]:
-                return render(
-                    request, "core/metadataForm.html",
-                    {
-                        "DATA_FORM": response["data"]["m_form"],
-                        "success": response["success"],
-                        "errors": response["errors"]
-                    }
-                )
-            if "m_batch_form" in response["data"]:
-                return render(
-                    request, "core/metadataForm.html",
-                    {
-                        "DATA_BATCHFORM": response["data"]["m_batch_form"],
-                        "DATA_SAMPLESAVED": response["data"]["sample_saved"],
-                        "success": response["success"],
-                        "errors": response["errors"]
-                    }
-                )
-            if "sample_saved" in response["data"]:
-                return render(
-                    request, "core/metadataForm.html",
-                    {
-                        "DATA_SAMPLESAVED": response["data"]["sample_saved"],
-                        "success": response["success"],
-                        "errors": response["errors"]
-                    }
-                )
-
-        if action == "defineBatch":
-            response = metadata_services.handle_define_batch(
-                request.POST, request.user, schema_obj
-            )
-            if "m_batch_form" in response["data"]:
-                return render(
-                    request, "core/metadataForm.html",
-                    {
-                        "DATA_BATCHFORM": response["data"]["m_batch_form"],
-                        "DATA_SAMPLESAVED": response["data"]["sample_saved"],
-                        "success": response["success"],
-                        "errors": response["errors"]
-                    }
-                )
-            if "sample_recorded" in response["data"]:
-                return render(
-                    request, "core/metadataForm.html",
-                    {
-                        "DATA_SAMPLERECORDED": response["data"]["sample_recorded"],
-                        "success": response["success"],
-                        "errors": response["errors"]
-                    }
-                )
-
-    # GET request or fallback
-    response = metadata_services.get_metadata_form_initial(request.user, schema_obj)
-    if "m_batch_form" in response["data"]:
-        return render(
-            request, "core/metadataForm.html",
-            {
-                "DATA_BATCHFORM": response["data"]["m_batch_form"],
-                "DATA_SAMPLESAVED": response["data"]["sample_saved"],
-                "success": response["success"],
-                "errors": response["errors"]
-            }
-        )
-    if not response["success"]:
-        return render(
-            request, "core/metadataForm.html",
-            {"errors": response["errors"]}
-        )
-    return render(
-        request, "core/metadataForm.html",
-        {
-            "DATA_FORM": response["data"]["m_form"],
-            "success": response["success"],
-            "errors": response["errors"]
-        }
+    action = request.POST.get("action") if request.method == "POST" else None
+    response = metadata_services.handle_metadata_form(
+        action=action,
+        post_data=request.POST if request.method == "POST" else None,
+        files=request.FILES if request.method == "POST" else None,
+        user=request.user,
+        schema_obj=schema_obj,
     )
+    context = {
+        **response.get("data", {}),
+        "success": response.get("success"),
+        "errors": response.get("errors"),
+    }
+    return render(request, "core/metadataForm.html", context)
 
 
 # TODO: this needs serialized-based refactor

--- a/core/views.py
+++ b/core/views.py
@@ -29,12 +29,14 @@ import core.utils.samples_graphics
 import core.utils.samples_map
 
 
-# FIXME: This needs to homogenize the way passing data to template.
-# FIXME: fornt end needs to manage error screen
-# TODO: update the strucuture object that its going to be rendered
 def index(request):
-    index_data = core.services.get_index_data()
-    return render(request, "core/index.html", {"data": index_data["data"]})
+    response = core.services.get_index_data()
+    context = {
+        **response.get("data", {}),
+        "success": response.get("success"),
+        "errors": response.get("errors"),
+    }
+    return render(request, "core/index.html", context)
 
 
 @login_required()


### PR DESCRIPTION
## Summary
- move sample assignment logic to dedicated service module
- expose lab utilities and update imports across app
- refactor assign samples view to use new service pattern
- standardize sample assignment service to accept POST payloads
- streamline assign samples view context handling
- refactor metadataform 
- refactor annotation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689360bebfe8832e9730dea4938e2d4a